### PR TITLE
fix bug with multiple modes, revolve accounts

### DIFF
--- a/revolve.pl
+++ b/revolve.pl
@@ -5,7 +5,7 @@ use Irssi::TextUI;
 use POSIX 'strftime';
 use vars qw($VERSION %IRSSI);
 
-$VERSION = "0.0.6"; # 29d237f4fda2f0d
+$VERSION = "0.0.7"; # 44a0e73e6885e08
 %IRSSI = (
     authors => 'Ryan Freebern',
     contact => 'ryan@freebern.org',

--- a/revolve.pl
+++ b/revolve.pl
@@ -278,6 +278,7 @@ sub summarize {
                 } else {
                     push @{$door{+MODES}}, [ $type eq '+' ? $p : "$p:", $args[$i] ];
                 }
+		$i++;
             }
         }
     }

--- a/revolve.pl
+++ b/revolve.pl
@@ -81,6 +81,7 @@ my %msg_level_style = (
     # line colour
     -1        => '%w',
    );
+my $lost_mode_style = '%r';
 #
 # here is the time format / style to use if time display is enabled:
 # %%H:%%M are passed to strftime
@@ -280,6 +281,11 @@ sub summarize {
                 }
 		$i++;
             }
+        }
+        foreach (@{$door{+MODES}}) {
+	    if ($_->[0] =~ s/^(.*)://) {
+		$_->[0] = $lost_mode_style . $1 . ':' . $msg_level_style{-1} . $_->[0];
+	    }
         }
     }
 

--- a/revolve.pl
+++ b/revolve.pl
@@ -338,25 +338,33 @@ sub delete_and_summarize {
 sub summarize_join {
     my ($server, $channel, $nick, $address, $reason) = @_;
     local our @summary = ($server->{tag}, $channel, $nick, undef, JOINS);
+    Irssi::term_refresh_freeze;
     &Irssi::signal_continue;
+    Irssi::term_refresh_thaw;
 }
 
 sub summarize_quit {
     my ($server, $nick, $address, $reason) = @_;
     local our @summary = ($server->{tag}, undef, $nick, undef, QUITS);
+    Irssi::term_refresh_freeze;
     &Irssi::signal_continue;
+    Irssi::term_refresh_thaw;
 }
 
 sub summarize_part {
     my ($server, $channel, $nick, $address, $reason) = @_;
     local our @summary = ($server->{tag}, $channel, $nick, undef, PARTS);
+    Irssi::term_refresh_freeze;
     &Irssi::signal_continue;
+    Irssi::term_refresh_thaw;
 }
 
 sub summarize_nick {
     my ($server, $new_nick, $old_nick, $address) = @_;
     local our @summary = ($server->{tag}, undef, $old_nick, $new_nick, NICKS);
+    Irssi::term_refresh_freeze;
     &Irssi::signal_continue;
+    Irssi::term_refresh_thaw;
 }
 
 sub update_prefixes {
@@ -376,9 +384,11 @@ sub summarize_irc_mode {
     my $modes = $prefix_tbl{$server->{tag}}[1];
     return unless $spec =~ /^([-+][\Q$modes\E]+)+$/;
     local our @summary = ($server->{tag}, $channel, $nick, $mode, MODES);
+    Irssi::term_refresh_freeze;
     &Irssi::signal_continue;
     my $dest = $server->format_create_dest($channel, MSGLEVEL_MODES, $server->window_find_closest($channel, MSGLEVEL_MODES));
     Irssi::signal_emit('print starting', $dest);
+    Irssi::term_refresh_thaw;
 }
 
 Irssi::signal_register({'print starting'=>[qw[Irssi::UI::TextDest]]});


### PR DESCRIPTION
- Fix an important bug involving multiple modes on the same line, that would get accounted to the wrong nick!
- add styling of removed modes
- optionally revolve account messages
- improve on-screen performance